### PR TITLE
fix condition in useSpacing

### DIFF
--- a/src/context.tsx
+++ b/src/context.tsx
@@ -21,7 +21,7 @@ type UseSpacing = {
 export const useSpacing: UseSpacing = (space?: number): any => {
   const { spacing } = useContext(Context)
   const multiply = (n: number) => n * spacing
-  return space ? multiply(space) : multiply
+  return space !== undefined ? multiply(space) : multiply
 }
 
 export const useDebugStyle = () => {


### PR DESCRIPTION
This fixes an error when pass `0` to the `useSpacing` hook since `0` is treated as false.