### PR TITLE
Adds defaultWidth to Columns  and defaultHeight to Rows

### DIFF
--- a/docs/api/components/columns.mdx
+++ b/docs/api/components/columns.mdx
@@ -41,6 +41,7 @@ const App = () => {
 render(<App />)
 ```
 
+
 ### Width
 
 ```jsx live
@@ -152,6 +153,35 @@ const App = () => {
 render(<App />)
 ```
 
+### Default Width
+
+```jsx live
+const App = () => {
+  return (
+    <Stack space={4}>
+      <Columns defaultWidth="1/2" space={4}>
+        <Placeholder />
+        <Placeholder />
+      </Columns>
+
+      <Columns defaultWidth="1/3" space={4}>
+        <Placeholder />
+        <Placeholder />
+      </Columns>
+
+      <Columns defaultWidth="1/4" space={4}>
+        <Placeholder />
+        <Placeholder />
+        <Column width="1/2">
+          <Placeholder />
+        </Column>
+      </Columns>
+    </Stack>
+  )
+}
+
+render(<App />)
+```
 
 ### Fluid Height
 

--- a/docs/api/components/rows.mdx
+++ b/docs/api/components/rows.mdx
@@ -78,6 +78,36 @@ const App = () => {
 render(<App />)
 ```
 
+### Default Height
+
+```jsx live
+const App = () => {
+  return (
+    <Stack space={4}>
+      <Rows defaultHeight="1/2" space={4}>
+        <Placeholder />
+        <Placeholder />
+      </Rows>
+
+      <Rows defaultHeight="1/3" space={4}>
+        <Placeholder />
+        <Placeholder />
+      </Rows>
+
+      <Rows defaultHeight="1/4" space={4}>
+        <Placeholder />
+        <Placeholder />
+        <Row height="1/2">
+          <Placeholder />
+        </Row>
+      </Rows>
+    </Stack>
+  )
+}
+
+render(<App />)
+```
+
 ### AlignX
 
 ```jsx live

--- a/example/src/typescript/screens/Playground/index.tsx
+++ b/example/src/typescript/screens/Playground/index.tsx
@@ -11,7 +11,7 @@ import {
   Rows,
   Row,
   Hidden,
-  reset,
+  unset,
 } from '@mobily/stacks'
 
 import styled from 'styled-components/native'
@@ -42,7 +42,7 @@ export const Playground = () => {
         <Text>Styled component</Text>
       </Item>
       <Box style={{ height: 400 }}>
-        <FillView alignX="center" alignY="center" right={reset}>
+        <FillView alignX="center" alignY="center" right={unset}>
           <Text>abc</Text>
         </FillView>
       </Box>
@@ -198,7 +198,7 @@ export const Playground = () => {
             </Placeholder>
           </Stack>
           <Columns style={{ backgroundColor: 'white' }} alignX="evenly">
-            <Column width="content" height="fluid">
+            <Column width="content">
               <Box alignX="center" flex="fluid">
                 <Box style={{ width: 40, height: 40, backgroundColor: 'pink' }}></Box>
                 <Box style={{ width: 4, backgroundColor: 'red' }} flex="fluid"></Box>

--- a/src/Stacks_component_Column.res
+++ b/src/Stacks_component_Column.res
@@ -11,7 +11,7 @@ module Box = Stacks_component_Box
 @gentype @react.component
 let make = (
   // Column props
-  ~width: responsiveProp<flex>=[#fluid],
+  ~width: option<responsiveProp<flex>>=?,
   // Box props
   ~padding=?,
   ~paddingX=?,
@@ -72,11 +72,11 @@ let make = (
   ~onMouseOut=?,
   ~onMouseUp=?,
 ) => {
-  let {isCollapsed, space, alignY, height} = useColumns()
+  let {isCollapsed, space, alignY, height, width: defaultWidth} = useColumns()
   let alignY = coerce(alignY)
   let boxPaddingLeft = isCollapsed ? None : space
   let marginTop = isCollapsed ? space : None
-  let flex = isCollapsed ? None : Some(width)
+  let flex = isCollapsed ? None : Belt.Option.isSome(width) ? width : defaultWidth
   let height = isCollapsed ? Some([#content]) : height
 
   <Box

--- a/src/Stacks_component_Columns.res
+++ b/src/Stacks_component_Columns.res
@@ -19,6 +19,7 @@ let make = (
   ~alignX: option<responsiveProp<[axisX | space]>>=?,
   ~alignY: option<responsiveProp<axisY>>=?,
   ~collapseBelow: option<string>=?,
+  ~defaultWidth: responsiveProp<flex>=[#fluid],
   // Box props
   ~padding=?,
   ~paddingX=?,
@@ -108,6 +109,7 @@ let make = (
       space: space,
       alignY: alignY,
       height: Some(height),
+      width: Some(defaultWidth),
     }
     value
   }, (isCollapsed, space, alignY, height))

--- a/src/Stacks_component_Row.res
+++ b/src/Stacks_component_Row.res
@@ -7,7 +7,7 @@ module Box = Stacks_component_Box
 let make = (
   // Column props
   ~width: responsiveProp<flex>=[#fluid],
-  ~height: responsiveProp<flex>=[#fluid],
+  ~height: option<responsiveProp<flex>>=?,
   // Box props
   ~padding=?,
   ~paddingX=?,
@@ -68,9 +68,11 @@ let make = (
   ~onMouseOut=?,
   ~onMouseUp=?,
 ) => {
-  let {space} = useRows()
+  let {space, defaultHeight} = useRows()
 
-  <Box direction=[#row] flex=height paddingTop=?space>
+  let height = Belt.Option.isSome(height) ? height : defaultHeight
+
+  <Box direction=[#row] flex=?height paddingTop=?space>
     <Box
       flex=width
       ?padding

--- a/src/Stacks_component_Rows.res
+++ b/src/Stacks_component_Rows.res
@@ -13,6 +13,7 @@ let make = (
   ~reverse=?,
   ~alignX: option<responsiveProp<[axisX]>>=?,
   ~alignY: option<responsiveProp<[axisY | space]>>=?,
+  ~defaultHeight: responsiveProp<flex>=[#fluid],
   // Box props
   ~padding=?,
   ~paddingX=?,
@@ -91,6 +92,7 @@ let make = (
   let config = React.useMemo1(() => {
     let value: RowsContext.t = {
       space: space,
+      defaultHeight: Some(defaultHeight),
     }
     value
   }, [space])

--- a/src/Stacks_context.res
+++ b/src/Stacks_context.res
@@ -25,6 +25,7 @@ module ColumnsContext = {
     space: option<responsiveProp<float>>,
     alignY: option<responsiveProp<axisY>>,
     height: option<responsiveProp<flex>>,
+    width: option<responsiveProp<flex>>,
   }
 
   let context = React.createContext({
@@ -32,6 +33,7 @@ module ColumnsContext = {
     space: None,
     alignY: None,
     height: None,
+    width: None,
   })
   let useColumns = () => React.useContext(context)
 
@@ -46,9 +48,15 @@ module ColumnsContext = {
 }
 
 module RowsContext = {
-  type t = {space: option<responsiveProp<float>>}
+  type t = {
+    space: option<responsiveProp<float>>,
+    defaultHeight: option<responsiveProp<flex>>,
+  }
 
-  let context = React.createContext({space: None})
+  let context = React.createContext({
+    space: None,
+    defaultHeight: None,
+  })
   let useRows = () => React.useContext(context)
 
   module Provider = {


### PR DESCRIPTION
Due to changes in v2 i wanted to add possibility to remove more boilerplate. `<Column />` (width) and `<Row />` (height) has default value `fluid`. To change that u need to add extra node with `width="flexProps"` or  `"height="flexProps"` so i've added possibility to add default behavior to `<Columns />` or `<Rows />` component.

Problem:

```
<Columns>
  <Column width="content">
    <Content />
  </Column>
  <Column width="content">
    <Content />
  </Column>
</Column>
```

Solution:
```
<Columns defaultWidth="content">
  <Content />
  <Content />
</Column>
```
